### PR TITLE
[RESEARCH] Analyze current build system and dependencies

### DIFF
--- a/docs/BUILD_SYSTEM_ANALYSIS.md
+++ b/docs/BUILD_SYSTEM_ANALYSIS.md
@@ -1,0 +1,131 @@
+# KaTrain Build System Analysis
+
+## Overview
+This document provides a comprehensive analysis of KaTrain's build system, dependencies, and platform-specific requirements for macOS Metal compilation.
+
+## Python Dependencies
+
+### Core Dependencies (from pyproject.toml)
+- **Python Version**: 3.9-3.13 (requires-python = ">=3.9,<3.14")
+- **pygame~=2.0**: macOS-specific dependency for window handling
+- **screeninfo>=0.8.1,<0.9**: Non-macOS platforms only
+- **chardet>=5.2.0,<6**: Character encoding detection
+- **docutils>=0.21.2**: Documentation utilities
+- **ffpyplayer>=4.5.1**: Media player (excluded on macOS in PyInstaller)
+- **urllib3>=2.2.2**: HTTP library
+- **kivy>=2.3.1**: Core GUI framework
+- **kivymd==0.104.1**: Material Design components for Kivy
+
+### Development Dependencies
+- **black>=24.8.0,<25**: Code formatter (required, line-length=120)
+- **polib>=1.2.0,<2**: Internationalization/translation tools
+- **pyinstaller>=6.14.1**: Application bundler
+- **pytest>=8.3.2,<9**: Testing framework
+- **tomli>=1.2.0**: TOML parser (Python < 3.11 only)
+
+### Build System
+- **Backend**: Hatchling (modern Python packaging)
+- **Tool**: UV package manager support configured
+
+## KataGo Binary Integration
+
+### Binary Loading Logic (katrain/core/engine.py)
+1. **Windows**: `katrain/KataGo/katago.exe`
+2. **Linux**: `katrain/KataGo/katago`
+3. **macOS**: 
+   - Primary: `katrain/KataGo/katago-osx` (bundled)
+   - Fallback: System `katago` (e.g., from Homebrew)
+   - Special handling for ARM64 Macs
+
+### Platform Detection
+- Uses Kivy's platform detection
+- Special case for ARM64 Macs (checks `platform.version()`)
+- Searches PATH + `/opt/homebrew/bin/` for system installations
+
+## PyInstaller Configuration Analysis
+
+### Key Features (spec/KaTrain.spec)
+1. **Cross-platform support**: Windows, macOS, Linux
+2. **Platform-specific handling**:
+   - Windows: Dual builds (console/GUI), code signing
+   - macOS: App bundle creation, document type associations
+   - Linux: Standard executable
+
+### macOS-Specific Build Details
+1. **Dependencies**:
+   - Excludes ffpyplayer and pygame to avoid SDL2 conflicts
+   - Includes katago-osx binary if present
+
+2. **App Bundle Configuration**:
+   - Bundle ID: `org.katrain.KaTrain`
+   - High resolution support enabled
+   - SGF file type association configured
+   - Icon: `katrain/img/icon.icns`
+
+3. **Environment Variables**:
+   - `KIVY_HEADLESS=1`: Prevents window creation during build
+   - `KATRAIN_VERSION`: Used for app bundle version
+
+### Data Files Included
+- GUI layouts: `gui.kv`, `popups.kv`
+- Configuration: `config.json`
+- Resources: models/, sounds/, img/, fonts/, i18n/
+- KataGo binaries and configs: KataGo/
+
+## Platform-Specific Code Locations
+
+### Build System
+- `spec/KaTrain.spec`: Platform conditionals throughout
+- `katrain/core/engine.py`: Binary path selection logic
+
+### GUI/Runtime
+- pygame dependency: macOS-only for window handling
+- screeninfo dependency: Excluded on macOS
+
+## Build Process Flow
+
+1. **Development Install**:
+   ```bash
+   uv pip install -e .  # or pip3 install -e .
+   ```
+
+2. **Build Preparation**:
+   - Format code: `black -l 120 .`
+   - Run tests: `pytest`
+   - Build translations: `python3 i18n.py`
+
+3. **Executable Creation**:
+   ```bash
+   pyinstaller spec/KaTrain.spec
+   ```
+
+4. **Output**:
+   - Windows: `dist/KaTrain/` (folder) and `dist/KaTrain.exe` (single file)
+   - macOS: `dist/KaTrain.app` (app bundle)
+   - Linux: `dist/KaTrain/` (folder)
+
+## Metal Support Considerations
+
+### Current State
+- KataGo binary (`katago-osx`) included in bundle supports Metal
+- No Metal-specific code in Python/Kivy layer
+- Metal acceleration happens entirely within KataGo
+
+### Compilation Requirements
+To compile from scratch with Metal:
+1. Need to build KataGo with Metal backend enabled
+2. Replace bundled `katago-osx` with custom-built binary
+3. No changes needed to Python/Kivy code
+4. PyInstaller configuration already handles binary inclusion
+
+## Risks and Challenges
+
+1. **Binary Architecture**: Need to ensure KataGo binary matches system architecture (Intel vs ARM64)
+2. **Code Signing**: macOS requires proper signing for distribution
+3. **Dependency Conflicts**: SDL2 conflicts between pygame/ffpyplayer on macOS
+4. **Metal API Version**: Need to verify minimum macOS/Metal version requirements
+
+## Next Steps
+1. Research KataGo source compilation with Metal backend
+2. Set up proper build environment with all dependencies
+3. Create automated build scripts for reproducible builds

--- a/docs/DEPENDENCY_TREE.md
+++ b/docs/DEPENDENCY_TREE.md
@@ -1,0 +1,95 @@
+# KaTrain Dependency Tree
+
+## Python Dependencies Hierarchy
+
+### Core Application Dependencies
+```
+KaTrain
+├── kivy>=2.3.1                  # Core GUI framework
+│   ├── SDL2                     # Window/graphics backend
+│   ├── OpenGL                   # Graphics rendering
+│   └── Cython                   # Performance extensions
+├── kivymd==0.104.1              # Material Design UI components
+│   └── kivy (peer dependency)
+├── pygame~=2.0 (macOS only)     # Window handling on macOS
+│   └── SDL2                     # Shared with Kivy
+├── screeninfo>=0.8.1 (non-macOS) # Screen detection
+├── chardet>=5.2.0               # Character encoding detection
+├── docutils>=0.21.2             # Documentation processing
+├── ffpyplayer>=4.5.1            # Audio/video playback
+│   └── FFmpeg libraries
+└── urllib3>=2.2.2               # HTTP client library
+```
+
+### Development Dependencies
+```
+Development Tools
+├── black>=24.8.0                # Code formatter
+├── polib>=1.2.0                 # i18n/translation tools
+├── pytest>=8.3.2                # Testing framework
+│   ├── pluggy
+│   └── pytest plugins
+├── pyinstaller>=6.14.1          # Executable builder
+│   ├── altgraph                 # Dependency graph
+│   ├── macholib (macOS)         # Mach-O binary handling
+│   └── pefile (Windows)         # PE binary handling
+└── tomli>=1.2.0 (Python<3.11)   # TOML parser
+```
+
+### System Dependencies
+
+#### macOS
+- Xcode Command Line Tools (for compilation)
+- Python 3.9-3.13
+- SDL2 (via pygame/Kivy)
+- OpenGL support (built-in)
+- Metal framework (for KataGo, built-in)
+
+#### KataGo Binary Dependencies
+- C++ runtime libraries
+- OpenCL/CUDA/Metal drivers (platform-specific)
+- zlib compression library
+- OpenSSL (for network features)
+
+## Platform-Specific Dependency Notes
+
+### macOS Specifics
+1. **pygame**: Required for proper window handling
+2. **ffpyplayer**: Excluded in PyInstaller to avoid SDL2 conflicts
+3. **Metal Support**: Provided by system, no additional dependencies
+
+### Dependency Conflicts
+1. **SDL2 Duplication**: Both Kivy and pygame use SDL2
+   - Resolved by excluding ffpyplayer on macOS
+2. **Binary Architecture**: Must match system (x86_64 vs arm64)
+
+## Version Constraints
+- Python: >=3.9, <3.14
+- Kivy: >=2.3.1 (no upper bound)
+- KivyMD: ==0.104.1 (pinned version)
+- All other deps use compatible version specifiers (~= or >=)
+
+## Hidden Dependencies
+These are discovered at runtime or build time:
+1. **Kivy providers**: Audio, video, window providers selected at runtime
+2. **Platform libraries**: 
+   - macOS: CoreAudio, CoreVideo, Metal
+   - Windows: DirectX, Windows Media
+   - Linux: ALSA, PulseAudio, X11/Wayland
+
+## KataGo Integration Points
+1. **Subprocess Communication**: No Python dependencies
+2. **Binary Location**: Hardcoded paths in engine.py
+3. **Configuration**: JSON files in KataGo directory
+4. **Models**: Neural network files in models/
+
+## Build-Time Dependencies
+1. **Hatchling**: Modern Python build backend
+2. **UV**: Fast Python package manager (optional)
+3. **PyInstaller Hooks**: Custom hooks for Kivy/KivyMD
+
+## Dependency Installation Order
+1. System dependencies (Xcode, Python)
+2. Core Python packages (pip, setuptools)
+3. Application dependencies (via pyproject.toml)
+4. KataGo binary (pre-compiled or built separately)

--- a/docs/METAL_COMPILATION_RISKS.md
+++ b/docs/METAL_COMPILATION_RISKS.md
@@ -1,0 +1,128 @@
+# Metal Compilation Risk Assessment
+
+## Critical Risks
+
+### 1. Missing macOS KataGo Binary ⚠️ HIGH
+**Issue**: Repository lacks the expected `katago-osx` binary
+- Current `katago` file is a Linux ELF binary
+- Code expects `katrain/KataGo/katago-osx`
+- Will fall back to system katago if available
+
+**Mitigation**: 
+- Must compile KataGo from source with Metal support
+- Or download pre-built macOS binary from KataGo releases
+
+### 2. Architecture Mismatch ⚠️ HIGH
+**Issue**: Intel vs Apple Silicon compatibility
+- Code has basic ARM64 detection
+- No universal binary support
+- Different Metal performance characteristics
+
+**Mitigation**:
+- Build architecture-specific binaries
+- Enhance detection logic
+- Consider universal binary creation
+
+## Moderate Risks
+
+### 3. Metal API Version Requirements ⚠️ MEDIUM
+**Issue**: Minimum macOS/Metal versions unclear
+- KataGo Metal backend requirements unknown
+- Older macOS versions may lack features
+- Performance variations across Metal versions
+
+**Mitigation**:
+- Research KataGo Metal requirements
+- Set minimum macOS version (likely 10.13+)
+- Test on various macOS versions
+
+### 4. SDL2 Library Conflicts ⚠️ MEDIUM
+**Issue**: Multiple packages use SDL2
+- Kivy and pygame both depend on SDL2
+- Current solution excludes ffpyplayer
+- May cause runtime issues
+
+**Mitigation**:
+- Current exclusion strategy works
+- Monitor for SDL2 version conflicts
+- Test audio/video functionality
+
+### 5. Code Signing & Notarization ⚠️ MEDIUM
+**Issue**: macOS security requirements
+- Unsigned apps show security warnings
+- Gatekeeper blocks unsigned apps
+- Notarization required for distribution
+
+**Mitigation**:
+- Set up Apple Developer account
+- Implement proper signing workflow
+- Add notarization to build process
+
+## Low Risks
+
+### 6. PyInstaller Compatibility ⚠️ LOW
+**Issue**: Bundling with Metal-enabled binary
+- PyInstaller configuration seems adequate
+- Binary inclusion already handled
+- May need hook adjustments
+
+**Mitigation**:
+- Current spec file should work
+- Test thoroughly after Metal binary integration
+
+### 7. Dependency Version Conflicts ⚠️ LOW
+**Issue**: Python package compatibility
+- Well-maintained dependency versions
+- Kivy 2.3.1+ supports macOS well
+- pygame 2.0 is stable on macOS
+
+**Mitigation**:
+- Lock versions after successful build
+- Regular dependency updates
+- Comprehensive testing
+
+## Unknown Factors
+
+### 1. KataGo Metal Performance
+- Compilation optimization flags
+- Metal shader compilation
+- Memory management differences
+
+### 2. Neural Network Compatibility
+- Model format compatibility
+- Precision differences (FP16 vs FP32)
+- Metal Performance Shaders usage
+
+### 3. Multi-GPU Support
+- External GPU handling
+- GPU switching on MacBooks
+- Metal device selection
+
+## Risk Matrix
+
+| Risk | Impact | Probability | Priority |
+|------|--------|-------------|----------|
+| Missing macOS Binary | High | Certain | Critical |
+| Architecture Mismatch | High | High | Critical |
+| Metal API Version | Medium | Medium | Medium |
+| SDL2 Conflicts | Medium | Low | Low |
+| Code Signing | Medium | High | Medium |
+| PyInstaller | Low | Low | Low |
+| Dependencies | Low | Low | Low |
+
+## Recommended Risk Mitigation Steps
+
+1. **Immediate Actions**:
+   - Obtain or compile katago-osx binary
+   - Test on both Intel and Apple Silicon
+   - Document Metal version requirements
+
+2. **Before Production**:
+   - Set up code signing
+   - Create universal binary
+   - Comprehensive platform testing
+
+3. **Ongoing Monitoring**:
+   - Track KataGo updates
+   - Monitor Metal API changes
+   - User feedback on performance

--- a/docs/PLATFORM_SPECIFIC_CODE.md
+++ b/docs/PLATFORM_SPECIFIC_CODE.md
@@ -1,0 +1,104 @@
+# Platform-Specific Code Inventory
+
+## Files with Platform-Specific Logic
+
+### 1. katrain/core/engine.py
+**Purpose**: KataGo binary path selection
+```python
+# Lines 66-73: Platform-specific binary selection
+if kivy_platform == "win":
+    exe = "katrain/KataGo/katago.exe"
+elif kivy_platform == "linux":
+    exe = "katrain/KataGo/katago"
+else:
+    exe = find_package_resource("katrain/KataGo/katago-osx")  # macOS
+    if not os.path.isfile(exe) or "arm64" in platform.version().lower():
+        exe = "katago"  # Fallback to system katago
+```
+
+**macOS Specifics**:
+- Looks for `katago-osx` binary (currently missing in repo)
+- Special handling for ARM64 Macs
+- Falls back to system-installed katago
+- Checks `/opt/homebrew/bin/` for Homebrew installations
+
+### 2. katrain/__main__.py
+**Purpose**: Application entry point with platform setup
+- May contain platform-specific initialization
+- Window management setup
+
+### 3. katrain/gui/sound.py
+**Purpose**: Audio playback implementation
+- Platform-specific audio providers
+- May use different backends on macOS vs others
+
+### 4. katrain/gui/popups.py
+**Purpose**: Dialog and popup implementations
+- Platform-specific file dialogs
+- Native OS integration for file selection
+
+### 5. katrain/gui/widgets/filebrowser.py
+**Purpose**: File browser widget
+- Platform-specific path handling
+- OS-specific file system navigation
+
+### 6. spec/KaTrain.spec (PyInstaller)
+**Platform Detection**:
+```python
+is_windows = sys.platform.startswith('win')
+is_macos = sys.platform == 'darwin'
+is_linux = sys.platform.startswith('linux')
+```
+
+**macOS-Specific Build Configuration**:
+- Excludes ffpyplayer and pygame to avoid conflicts
+- Creates .app bundle with proper metadata
+- Handles code signing and notarization
+- SGF file type associations
+
+### 7. pyproject.toml
+**Platform-Specific Dependencies**:
+```toml
+"pygame~=2.0 ; platform_system == 'Darwin'"
+"screeninfo>=0.8.1,<0.9 ; platform_system != 'Darwin'"
+```
+
+## Platform-Specific Features
+
+### macOS
+1. **Window Management**: Uses pygame for proper window handling
+2. **App Bundle**: Full .app creation with icon and file associations
+3. **Metal Support**: Through KataGo binary (no Python-level code)
+4. **Homebrew Integration**: Searches Homebrew paths for katago
+
+### Missing macOS Binary
+**Important**: The repository lacks `katago-osx` binary that the code expects. The included `katago` file is a Linux ELF binary, not macOS.
+
+## Build System Platform Handling
+
+### PyInstaller Spec
+1. **Data Files**: Same across platforms
+2. **Binaries**: Platform-specific inclusion
+3. **Hidden Imports**: Windows-specific modules
+4. **Excludes**: macOS-specific exclusions
+
+### Environment Variables (Build Time)
+- `KIVY_HEADLESS=1`: Prevents window creation
+- `KIVY_NO_WINDOW=1`: Disables window system
+- `KIVY_GL_BACKEND=mock`: Uses mock OpenGL
+
+## Recommendations for Metal Compilation
+
+1. **KataGo Binary**: Need to compile KataGo with Metal backend
+2. **Binary Placement**: Place as `katrain/KataGo/katago-osx`
+3. **Architecture Detection**: Enhance ARM64 detection logic
+4. **Path Handling**: Consider universal binary support
+
+## Testing Requirements
+
+### Platform-Specific Tests Needed
+1. Binary detection and loading
+2. Window management on macOS
+3. File dialog operations
+4. App bundle functionality
+5. Metal acceleration verification


### PR DESCRIPTION
## Description
Comprehensive analysis of KaTrain's build system, dependencies, and platform-specific requirements for macOS Metal compilation.

## Related Issue(s)
Closes #1

## Type of Change
- [x] Documentation update
- [x] Build/compilation improvement

## Changes Made
- Created BUILD_SYSTEM_ANALYSIS.md with complete build system overview
- Created DEPENDENCY_TREE.md with detailed dependency hierarchy
- Created PLATFORM_SPECIFIC_CODE.md with inventory of platform-specific code
- Created METAL_COMPILATION_RISKS.md with risk assessment and mitigation strategies

## Key Findings
1. **Missing macOS Binary**: The repository lacks the expected `katago-osx` binary. The current `katago` file is a Linux ELF binary.
2. **Architecture Support**: Code has basic ARM64 detection but needs enhancement for universal binary support.
3. **Metal Integration**: Metal support is entirely within KataGo binary - no Python-level changes needed.
4. **Build Process**: PyInstaller configuration is already set up for macOS app bundle creation.

## Testing
- [x] I have tested these changes locally
- [x] Not applicable (documentation only)

## Platform Testing
- [x] Not applicable (documentation only)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

## Additional Notes
This analysis provides the foundation for the subsequent phases of the Metal compilation project. The most critical next step is obtaining or compiling a proper macOS KataGo binary with Metal support.